### PR TITLE
Remove scratch files

### DIFF
--- a/0/scratch/Dockerfile
+++ b/0/scratch/Dockerfile
@@ -1,9 +1,0 @@
-FROM scratch
-LABEL maintainer "Bitnami <containers@bitnami.com>"
-
-COPY prebuildfs /
-
-COPY rootfs /
-
-USER 1001
-ENTRYPOINT [ "/kubernetes-event-exporter" ]

--- a/0/scratch/docker-compose.yml
+++ b/0/scratch/docker-compose.yml
@@ -1,4 +1,0 @@
-version: '2'
-services:
-  kubernetes-event-exporter:
-    image: docker.io/bitnami/kubernetes-event-exporter:0-scratch

--- a/0/scratch/prebuildfs/opt/bitnami/.bitnami_components.json
+++ b/0/scratch/prebuildfs/opt/bitnami/.bitnami_components.json
@@ -1,7 +1,0 @@
-{
-    "kubernetes-event-exporter": {
-        "digest": "eb5a1237ef12ad63b74fd3390f862d8008d2ae386f29c99c2de85b9fca609c76",
-        "type": "BLACKSMITH",
-        "version": "0.9.0"
-    }
-}

--- a/0/scratch/prebuildfs/opt/bitnami/licenses/licenses.txt
+++ b/0/scratch/prebuildfs/opt/bitnami/licenses/licenses.txt
@@ -1,3 +1,0 @@
-Bitnami containers ship with software bundles. You can find the licenses under:
-/opt/bitnami/nami/COPYING
-/opt/bitnami/[name-of-bundle]/licenses/[bundle-version].txt


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Following the migration from scratch to minideb, the files of the deprecated scratch base image need to be deleted.

**Benefits**

Repository clean-up

**Possible drawbacks**

None
